### PR TITLE
Fix parenthesis

### DIFF
--- a/editor/initial_code/python_3
+++ b/editor/initial_code/python_3
@@ -13,7 +13,7 @@ if __name__ == '__main__':
   4, 5, 6,
   6, 5, 5,
   7, 8, 0,
-  0]))
+  0])))
 
     # These "asserts" are used for self-checking and not for an auto-testing
     assert list(compress([


### PR DESCRIPTION
Parentheses in inline test code do not match.
(The mismatch introduced in the commit 04f8d339)